### PR TITLE
feat: [이승현] Remember Cloudflare WAF 회피를 위해 Selenium HTTP 헤더와 User-Agent를 설정합니다 [JSC-7]

### DIFF
--- a/src/main/java/com/wowraid/jobspooncrawler/remember/controller/CrawlerController.java
+++ b/src/main/java/com/wowraid/jobspooncrawler/remember/controller/CrawlerController.java
@@ -2,16 +2,20 @@ package com.wowraid.jobspooncrawler.remember.controller;
 
 import com.wowraid.jobspooncrawler.remember.entity.JobPosting;
 import com.wowraid.jobspooncrawler.remember.service.CrawlerService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
-
+@Slf4j
 @RestController
 @RequestMapping("/api")
 public class CrawlerController {
     @Autowired
     private CrawlerService crawlerService;
+    private String url= "https://career.rememberapp.co.kr/job/postings";
 //    @PostMapping("/crawl")
 //    public List<JobPosting> crawl(@RequestBody String filterJson) throws InterruptedException {
 //        return crawlerService.crawl(filterJson);
@@ -20,4 +24,30 @@ public class CrawlerController {
     public void test() throws InterruptedException {
         crawlerService.openChromeWindow();
     }
+    @GetMapping("/test_url")
+    public void testUrl() throws InterruptedException {
+        crawlerService.openChromeWindow();
+    }
+    // HTTP GET 요청을 '/test_url2' 엔드포인트에 매핑
+    @GetMapping("/test_url2")
+    public Mono<String> testUrl2() {// 쿼리 파라미터 'url'을 메서드 파라미터로 바인딩
+        // 1) Mono.fromCallable: Blocking 메서드(fetchPageSource)를 호출 가능한 형태로 래핑
+        //    호출 시점은 구독(subscribe)될 때
+        return Mono.fromCallable(() ->
+                        // 2) 실제로 URL 페이지 소스를 가져오는 Blocking 호출
+                        crawlerService.fetchPageSource(url)
+                )
+                // 3) 이 Callable이 실행될 스레드 풀 지정
+                //    boundedElastic: I/O·블로킹 작업 최적화 스레드 풀
+                .subscribeOn(Schedulers.boundedElastic())
+
+                // 4) 파이프라인에서 예외 발생 시 대체 흐름 정의
+                .onErrorResume(ex -> {
+                    // 4-1) 로깅: 어떤 예외가 터졌는지 스택트레이스와 함께 기록
+                    log.error("Error in testUrl2", ex);
+                    // 4-2) 에러 복구: 에러 메시지를 담은 단일 Mono<String> 반환
+                    return Mono.just("Error fetching URL: " + ex.getMessage());
+                });
+    }
+
 }

--- a/src/main/java/com/wowraid/jobspooncrawler/remember/service/CrawlerService.java
+++ b/src/main/java/com/wowraid/jobspooncrawler/remember/service/CrawlerService.java
@@ -1,22 +1,86 @@
 package com.wowraid.jobspooncrawler.remember.service;
 
-import com.wowraid.jobspooncrawler.remember.entity.JobPosting;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import lombok.extern.slf4j.Slf4j;
-import org.openqa.selenium.*;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
 @Slf4j
 @Service
 public class CrawlerService {
 
+    private static final String USER_AGENT = "'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'";
+
+    /**
+     * 지정된 URL을 ChromeDriver를 통해 가져온 뒤, HTML을 반환합니다.
+     */
+    public String fetchPageSource(String url) {
+        // 1) 메서드 진입 로그
+        log.info("[fetchPageSource] Start. URL={}", url);
+
+        // 2) ChromeDriver 자동 설치
+        WebDriverManager.chromedriver().setup();
+        log.info("[fetchPageSource] ChromeDriver setup complete");
+
+        // 3) ChromeOptions 설정
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--user-agent=" + USER_AGENT);
+        // 필요 시 헤드리스 모드 추가 가능
+        options.addArguments("--headless=new");
+        log.info("[fetchPageSource] ChromeOptions configured (headless={}, UA={})",
+                options.toString().contains("--headless"), USER_AGENT);
+
+        // 4) 드라이버 실행
+        WebDriver driver = new ChromeDriver(options);
+        log.info("[fetchPageSource] ChromeDriver session started");
+
+        try {
+            // 5) 페이지 이동
+            log.info("[fetchPageSource] Navigating to URL");
+            driver.get(url);
+            log.info("[fetchPageSource] Page loaded: {}", driver.getCurrentUrl());
+
+            // 6) JS 로딩 대기
+            log.info("[fetchPageSource] Waiting 2 seconds for JS to load");
+            Thread.sleep(2000);
+
+            // 7) 페이지 소스 및 제목 가져오기
+            String pageSource = driver.getPageSource();
+            String pageTitle  = driver.getTitle();
+            log.info("[fetchPageSource] Page fetched. title=\"{}\", sourceLength={}",
+                    pageTitle, pageSource.length());
+
+            return pageSource;
+        } catch (InterruptedException e) {
+            // 8) 인터럽트 예외 처리
+            Thread.currentThread().interrupt();
+            log.error("[fetchPageSource] Interrupted while sleeping", e);
+            return "";
+        } finally {
+            // 9) 리소스 정리
+            driver.quit();
+            log.info("[fetchPageSource] ChromeDriver session closed");
+        }
+    }
+    /**
+     * 페이지의 <title>을 가져옵니다.
+     */
+    public String fetchPageTitle(String url) {
+        Document doc = fetchDocument(url);
+        return doc.title();
+    }
+
+    /**
+     * fetch()로 가져온 HTML 문자열을 Jsoup으로 파싱하여 Document를 반환합니다.
+     */
+    public Document fetchDocument(String url) {
+        String html = fetchPageSource(url);
+        return Jsoup.parse(html);
+    }
     /**
      * Selenium Manager로 Chrome을 실행만 합니다.
      */

--- a/src/test/java/com/wowraid/jobspooncrawler/remember/service/CrawlerServiceTest.java
+++ b/src/test/java/com/wowraid/jobspooncrawler/remember/service/CrawlerServiceTest.java
@@ -1,0 +1,128 @@
+package com.wowraid.jobspooncrawler.remember.service;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * CrawlerService의 주요 메서드(fetchPageSource, fetchPageTitle, fetchDocument)를
+ * 데이터 URL 기반의 간단한 HTML로 검증하는 통합 테스트 클래스입니다.
+ *
+ * - Base64 data URL 방식을 사용하여 공백, 특수문자 인코딩 문제를 해결합니다.
+ * - Given-When-Then 형식으로 각 테스트의 의도를 명확히 주석 처리합니다.
+ */
+class CrawlerServiceTest {
+
+    private static CrawlerService crawlerService;
+
+    /**
+     * 테스트 전체에서 공유할 CrawlerService 인스턴스를 초기화합니다.
+     * WebDriverManager를 이용해 ChromeDriver 바이너리를 자동으로 설치/설정하도록 합니다.
+     */
+    @BeforeAll
+    static void setupClass() {
+        // Given: 아직 ChromeDriver가 설정되지 않은 상태
+        // When: WebDriverManager를 통해 크롬 드라이버를 자동으로 다운로드 및 경로 설정
+        WebDriverManager.chromedriver().setup();
+        // Then: crawlerService 인스턴스를 생성하여 테스트 준비 완료
+        crawlerService = new CrawlerService();
+    }
+
+    /**
+     * 주어진 HTML 문자열을 Base64로 인코딩하여
+     * data:text/html;base64,<base64> 형태의 data URL을 생성합니다.
+     *
+     * @param html 원본 HTML 문자열
+     * @return Base64 인코딩된 data URL
+     */
+    private static String makeDataUrl(String html) {
+        // Given: 인코딩할 HTML 문자열
+        byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
+        // When: Base64로 인코딩 수행
+        String base64 = Base64.getEncoder().encodeToString(bytes);
+        // Then: Base64 스킴을 사용한 data URL 반환
+        return "data:text/html;base64," + base64;
+    }
+
+    /**
+     * fetchPageSource()가 페이지의 전체 HTML을 정확히 반환하는지 검증합니다.
+     * Given-When-Then 구조로 테스트 흐름을 나눴습니다.
+     */
+    @Test
+    void fetchPageSource_shouldContainFullHtml() {
+        // Given: 간단한 HTML 문자열과 이를 Base64 data URL로 만든 URL
+        String html = "<html><head><title>Test Title</title></head>"
+                + "<body><h1>Hello</h1></body></html>";
+        String dataUrl = makeDataUrl(html);
+
+        // When: CrawlerService를 통해 페이지 소스(HTML 전체)를 가져옴
+        String pageSource = crawlerService.fetchPageSource(dataUrl);
+
+        // Then: 반환된 HTML 전체에 <title> 및 <h1> 요소가 포함되어야 함
+        assertNotNull(pageSource, "fetchPageSource()는 null을 반환하면 안 됩니다.");
+        assertTrue(
+                pageSource.contains("<title>Test Title</title>"),
+                "반환된 HTML에 <title>Test Title</title>이 포함되어야 합니다."
+        );
+        assertTrue(
+                pageSource.contains("<h1>Hello</h1>"),
+                "반환된 HTML에 <h1>Hello</h1>이 포함되어야 합니다."
+        );
+    }
+
+    /**
+     * fetchPageTitle()이 페이지의 <title> 요소만 정확히 추출하여 반환하는지 검증합니다.
+     * HTML 전체가 아닌, title() 호출을 통해서만 결과를 얻도록 역할을 분리했음을 전제로 합니다.
+     */
+    @Test
+    void fetchPageTitle_shouldReturnOnlyTitle() {
+        // Given: 테스트용 HTML 문자열과 Base64 data URL
+        String html = "<html><head><title>My Title</title></head>"
+                + "<body>…</body></html>";
+        String dataUrl = makeDataUrl(html);
+
+        // When: CrawlerService의 fetchPageTitle() 메서드를 호출
+        String title = crawlerService.fetchPageTitle(dataUrl);
+
+        // Then: 반환된 문자열이 정확히 "My Title"이어야 함
+        assertEquals(
+                "My Title",
+                title,
+                "fetchPageTitle()는 페이지의 <title> 값을 정확히 반환해야 합니다."
+        );
+    }
+
+    /**
+     * fetchDocument()가 Jsoup을 이용해 HTML을 파싱하여 Document 객체를 생성하는지 확인합니다.
+     * 파싱된 Document로부터 title과 특정 요소 텍스트를 검증합니다.
+     */
+    @Test
+    void fetchDocument_shouldParseJsoupDocument() {
+        // Given: id="para"를 가진 <p> 요소가 포함된 HTML과 Base64 data URL
+        String html = "<html><head><title>Doc Title</title></head>"
+                + "<body><p id=\"para\">Paragraph</p></body></html>";
+        String dataUrl = makeDataUrl(html);
+
+        // When: CrawlerService의 fetchDocument() 호출하여 Jsoup Document 획득
+        Document doc = crawlerService.fetchDocument(dataUrl);
+
+        // Then: Document가 null이 아니고, title과 p#para 텍스트가 예상대로 나와야 함
+        assertNotNull(doc, "fetchDocument() 결과 Document는 null이 아니어야 합니다.");
+        assertEquals(
+                "Doc Title",
+                doc.title(),
+                "Jsoup으로 파싱한 title이 'Doc Title'이어야 합니다."
+        );
+        assertEquals(
+                "Paragraph",
+                doc.getElementById("para").text(),
+                "id가 'para'인 요소의 텍스트가 'Paragraph'이어야 합니다."
+        );
+    }
+}


### PR DESCRIPTION
feat: [이승현] Remember Cloudflare WAF 회피를 위해 Selenium HTTP 헤더와 User-Agent를 설정합니다 [JSC-7]
chrome의 기본적 navigator.useragent값을 기본값으로 설정
Selenium을 통해 사이트 접속 , 결과값을 return합니다
관련 테스트코드로 해당값이 정상적으로 동작하는지 검증합니다.